### PR TITLE
Removed scalar type hints for parameters and return types

### DIFF
--- a/src/Block/Catalog/Product/Renderer/DefaultRenderer.php
+++ b/src/Block/Catalog/Product/Renderer/DefaultRenderer.php
@@ -76,17 +76,17 @@ class DefaultRenderer extends AbstractProduct implements RendererInterface
         parent::__construct($context, $data);
     }
 
-    public function setProductIds(int ...$productIds)
+    public function setProductIds($productIds)
     {
         $this->productIds = $productIds;
     }
 
-    public function getProductIds() : array
+    public function getProductIds()
     {
         return $this->productIds;
     }
 
-    public function render(): string
+    public function render()
     {
         return $this->toHtml();
     }
@@ -100,7 +100,7 @@ class DefaultRenderer extends AbstractProduct implements RendererInterface
      *
      * @throws NoSuchEntityException
      */
-    public function getProductById(int $productId): ProductInterface
+    public function getProductById($productId)
     {
         $cacheKey = 'product_' . $productId;
 
@@ -119,7 +119,7 @@ class DefaultRenderer extends AbstractProduct implements RendererInterface
      *
      * @return array
      */
-    public function getAddToCartPostParams(Product $product): array
+    public function getAddToCartPostParams(Product $product)
     {
         $url = $this->getAddToCartUrl($product);
 
@@ -139,7 +139,7 @@ class DefaultRenderer extends AbstractProduct implements RendererInterface
      *
      * @return string
      */
-    public function getTemplate() : string
+    public function getTemplate()
     {
         return $this->getData('template') ?? self::DEFAULT_TEMPLATE;
     }

--- a/src/Block/Catalog/Product/RendererInterface.php
+++ b/src/Block/Catalog/Product/RendererInterface.php
@@ -20,9 +20,9 @@ namespace TeamNeustaGmbh\Magentypo\Block\Catalog\Product;
  */
 interface RendererInterface
 {
-    public function setProductIds(int ...$productId);
+    public function setProductIds($productIds);
 
-    public function getProductIds() : array;
+    public function getProductIds();
 
-    public function render(): string;
+    public function render();
 }

--- a/src/Controller/Catalog/Product.php
+++ b/src/Controller/Catalog/Product.php
@@ -68,7 +68,7 @@ class Product extends Action
      * @param RendererInterface $renderer
      * @param \int[]            $productIds
      */
-    private function renderBlock(RendererInterface $renderer, int ...$productIds)
+    private function renderBlock(RendererInterface $renderer, $productIds)
     {
         $renderer->setProductIds($productIds);
         $this->renderResponse(200, $renderer->render());
@@ -80,7 +80,7 @@ class Product extends Action
      * @param int    $statusCode
      * @param string $body
      */
-    private function renderResponse(int $statusCode, string $body)
+    private function renderResponse($statusCode, $body)
     {
         /** @var Http $response */
         $response = $this->getResponse();


### PR DESCRIPTION
I had to remove the type hints for parameters and return values, because Magentos code generation can't handle these. This is fixes in Magento 2.2
If 2.2 is released / GA, it would be good to revert this change